### PR TITLE
Pervasive renames to internals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Construct a command line, combining in flags and positional parameters.
 
 ```scala
 val cmd = (MyArgs |*| (
-    option[Boolean]('f' -> "flag", "enable flag."),
-    [String]("author", "<pattern>").option,
-    option[String]("delim", "[|]").default("|"),
+    flag[Boolean]('f' -> "flag", "enable flag."),
+    flag[String]("author", "<pattern>").option,
+    flag[String]("delim", "[|]").default("|"),
     switch("dry-run"),
     positional.one[String]("<path>")
   )) ~ "myprogram" ~~ "My description"

--- a/src/main/scala/io.mth.pirate/Flags.scala
+++ b/src/main/scala/io.mth.pirate/Flags.scala
@@ -6,19 +6,19 @@ object Flags extends Flags
 
 trait Flags {
   private def parse[A](p: Parser[A]): Parse[A] =
-    PiratedParse(p, Metadata(None, true))
+    ParserParse(p, Metadata(None, true))
 
   def terminator[A](n: Name, a: A): Parse[A] =
-    parse(FlagParser(n, a))
+    parse(SwitchParser(n, a))
 
   def terminatorx[A: Read, B](n: Name, f: Option[A] => B): Parse[B] =
-    parse(OptionParser(n, List(), Read.of[A].option).map(f))
+    parse(FlagParser(n, List(), Read.of[A].option).map(f))
 
   def switch(n: Name): Parse[Boolean] =
-    parse(FlagParser(n, true)) ||| false.pure[Parse]
+    parse(SwitchParser(n, true)) ||| false.pure[Parse]
 
-  def option[A: Read](n: Name, meta: String): Parse[A] =
-    parse(OptionParser(n, List(meta), Read.of[A])) ||| ValueParse(None)
+  def flag[A: Read](n: Name, meta: String): Parse[A] =
+    parse(FlagParser(n, List(meta), Read.of[A])) ||| ValueParse(None)
 
   object positional {
     def one[A: Read](meta: String): Parse[A] =
@@ -28,7 +28,6 @@ trait Flags {
 
   object command {
     def of[A](name: String, p: Parse[A]): Parse[A] =
-      parse(SubCommandParser(name, p)) ||| ValueParse(None)
-
+      parse(CommandParser(name, p)) ||| ValueParse(None)
   }
 }

--- a/src/main/scala/io.mth.pirate/Name.scala
+++ b/src/main/scala/io.mth.pirate/Name.scala
@@ -2,15 +2,15 @@ package io.mth.pirate
 
 sealed trait Name {
   def short: Option[Char] = this match {
-    case Short(s) => Some(s)
-    case Long(_) => None
-    case Both(s, _) => Some(s)
+    case ShortName(s) => Some(s)
+    case LongName(_) => None
+    case BothName(s, _) => Some(s)
   }
 
   def long: Option[String] = this match {
-    case Short(_) => None
-    case Long(l) => Some(l)
-    case Both(_, l) => Some(l)
+    case ShortName(_) => None
+    case LongName(l) => Some(l)
+    case BothName(_, l) => Some(l)
   }
 
   def hasShort(s: Char): Boolean =
@@ -19,8 +19,8 @@ sealed trait Name {
   def hasLong(l: String): Boolean =
     long.map(_ == l).getOrElse(false)
 }
-// FIX rename these, not sure what I was thinking.
-case class Short(s: Char) extends Name
-case class Long(l: String) extends Name
-case class Both(s: Char, l: String) extends Name
-object Name { val apply = Both.apply _ }
+
+case class ShortName(s: Char) extends Name
+case class LongName(l: String) extends Name
+case class BothName(s: Char, l: String) extends Name
+object Name { def apply(s: Char, l: String) = BothName(s, l) }

--- a/src/main/scala/io.mth.pirate/Parse.scala
+++ b/src/main/scala/io.mth.pirate/Parse.scala
@@ -10,8 +10,8 @@ sealed trait Parse[A] {
   def map[B](f: A => B): Parse[B] = this match {
     case ValueParse(o) =>
       ValueParse(o.map(f))
-    case PiratedParse(p, m) =>
-      PiratedParse(p.map(f), m)
+    case ParserParse(p, m) =>
+      ParserParse(p.map(f), m)
     case ApParse(k, a) =>
       ApParse(k.map(ff => ff.map(f)), a)
     case AltParse(a, b) =>
@@ -29,7 +29,7 @@ sealed trait Parse[A] {
   def eval: Option[A] = this match {
     case ValueParse(o) =>
       o
-    case PiratedParse(p, m) =>
+    case ParserParse(p, m) =>
       None
     case ApParse(k, a) =>
       a.eval <*> k.eval
@@ -49,7 +49,7 @@ sealed trait Parse[A] {
     def go[C](multi: Boolean, dfault: Boolean, f: TreeTraverseF[B], p: Parse[C]): ParseTree[B] = p match {
       case ValueParse(_) =>
         ParseTreeAp(Nil)
-      case PiratedParse(p, m) =>
+      case ParserParse(p, m) =>
         ParseTreeLeaf(f.run(OptHelpInfo(multi, dfault), p, m))
       case ApParse(p1, p2) =>
         ParseTreeAp(List(go(multi, dfault, f, p1), go(multi, dfault, f, p2)))
@@ -85,7 +85,7 @@ sealed trait Parse[A] {
 }
 
 case class ValueParse[A](m: Option[A]) extends Parse[A]
-case class PiratedParse[A](p: Parser[A], m: Metadata) extends Parse[A]
+case class ParserParse[A](p: Parser[A], m: Metadata) extends Parse[A]
 case class ApParse[A, B](f: Parse[A => B], a: Parse[A]) extends Parse[B]
 case class AltParse[A](a: Parse[A], b: Parse[A]) extends Parse[A]
 case class BindParse[A, B](f: A => Parse[B], a: Parse[A]) extends Parse[B]

--- a/src/main/scala/io.mth.pirate/Parser.scala
+++ b/src/main/scala/io.mth.pirate/Parser.scala
@@ -4,18 +4,18 @@ import scalaz._, Scalaz._
 
 sealed trait Parser[A] {
   def map[B](f: A => B): Parser[B] = this match {
-    case FlagParser(flag, a) =>
-      FlagParser(flag, f(a))
-    case OptionParser(flag, metas, p) =>
-      OptionParser(flag, metas, p.map(f))
+    case SwitchParser(flag, a) =>
+      SwitchParser(flag, f(a))
+    case FlagParser(flag, metas, p) =>
+      FlagParser(flag, metas, p.map(f))
     case ArgumentParser(p) =>
       ArgumentParser(p.map(f))
-    case SubCommandParser(name, p) =>
-      SubCommandParser(name, p.map(f))
+    case CommandParser(name, p) =>
+      CommandParser(name, p.map(f))
   }
 }
 
-case class FlagParser[A](flag: Name, a: A) extends Parser[A]
-case class OptionParser[A](flag: Name, metas: List[String], p: Read[A]) extends Parser[A]
+case class SwitchParser[A](flag: Name, a: A) extends Parser[A]
+case class FlagParser[A](flag: Name, metas: List[String], p: Read[A]) extends Parser[A]
 case class ArgumentParser[A](p: Read[A]) extends Parser[A]
-case class SubCommandParser[A](name: String, p: Parse[A]) extends Parser[A]
+case class CommandParser[A](name: String, p: Parse[A]) extends Parser[A]

--- a/src/main/scala/io.mth.pirate/Read.scala
+++ b/src/main/scala/io.mth.pirate/Read.scala
@@ -135,13 +135,13 @@ object Read extends shapeless.ProductTypeClassCompanion[Read] {
   implicit def ReadString: Read[String] =
     string
 
-  implicit def ReadShort: Read[scala.Short] =
+  implicit def ReadShort: Read[Short] =
     tryRead(_.toShort, "Short")
 
   implicit def ReadInt: Read[Int] =
     tryRead(_.toInt, "Int")
 
-  implicit def ReadLong: Read[scala.Long] =
+  implicit def ReadLong: Read[Long] =
     tryRead(_.toLong, "Long")
 
   implicit def ReadDouble: Read[Double] =

--- a/src/main/scala/io.mth.pirate/Syntax.scala
+++ b/src/main/scala/io.mth.pirate/Syntax.scala
@@ -5,22 +5,22 @@ package io.mth.pirate
  *
  * eg.
  * {{{
- *   option[Int]('x') |||
- *     option[String]("something") |||
- *     option[String]('e' -> "example")
+ *   flag[Int]('x') |||
+ *     flag[String]("something") |||
+ *     flag[String]('e' -> "example")
  * }}}
  *
  * Instead of:
  *
  * {{{
- *   option[Int](Short('x')) |||
- *     option[String](Long("something")) |||
- *     option[String](Both('e', "example"))
+ *   flag[Int](ShortName('x')) |||
+ *     flag[String](LongName("something")) |||
+ *     flag[String](BothName('e', "example"))
  * }}}
  */
 trait Syntax {
 
-  implicit def ShortNameSyntax(s: Char) = Short(s)
-  implicit def LongNameSyntax(l: String) = Long(l)
-  implicit def BothNameSyntax(b: (Char, String)) = Both(b._1, b._2)
+  implicit def ShortNameSyntax(s: Char) = ShortName(s)
+  implicit def LongNameSyntax(l: String) = LongName(l)
+  implicit def BothNameSyntax(b: (Char, String)) = BothName(b._1, b._2)
 }

--- a/src/test/scala/io.mth.pirate.example/GitExample.scala
+++ b/src/test/scala/io.mth.pirate.example/GitExample.scala
@@ -25,13 +25,13 @@ object GitExample extends PirateMainIO[Git] {
     terminatorx("help", GitHelp.apply)
 
   val cwd: Parse[String] =
-    option('C', "<path>")
+    flag('C', "<path>")
 
   val conf: Parse[String] =
-    option('c', "<name>=<value>")
+    flag('c', "<name>=<value>")
 
   val exec: Parse[String] =
-    option("exec-path", "<path>") // FIX fork on arg terminator vs option
+    flag("exec-path", "<path>") // FIX fork on arg terminator vs option
 
   val html: Parse[GitCommand] =
     terminator("html-path", GitHtmlPath)

--- a/src/test/scala/io.mth.pirate.example/InteractiveExample.scala
+++ b/src/test/scala/io.mth.pirate.example/InteractiveExample.scala
@@ -13,8 +13,8 @@ object InteractiveExample {
 
   val example = Example |*| (
     switch('s')
-  , option[String]('c', "STRING")
-  , option[Int]('n', "INT")
+  , flag[String]('c', "STRING")
+  , flag[Int]('n', "INT")
   )
 
  val command = example ~ "example" ~~

--- a/src/test/scala/io.mth.pirate.example/MthExample.scala
+++ b/src/test/scala/io.mth.pirate.example/MthExample.scala
@@ -17,8 +17,8 @@ object MthExample {
 
   val example: Parse[Args] = (Example |*| (
     switch('s')
-  , option[String]('c', "STRING")
-  , option[Int]('n', "INT")
+  , flag[String]('c', "STRING")
+  , flag[Int]('n', "INT")
   )).map(x => x)
 
   val all = switch('h').as[Args](Help) ||| switch('v').as(Version) ||| example

--- a/src/test/scala/io.mth.pirate.internal/InterpretterSpec.scala
+++ b/src/test/scala/io.mth.pirate.internal/InterpretterSpec.scala
@@ -19,20 +19,20 @@ class InterpretterSpec extends test.Spec { def is = s2"""
   import Interpretter._
 
   def requiredFound =
-    run(option[String]('a', ""), List("-a", "b")) ==== "b".right
+    run(flag[String]('a', ""), List("-a", "b")) ==== "b".right
 
   def requiredMissing =
-    run(option[String]('a', ""), List()).toEither must beLeft
+    run(flag[String]('a', ""), List()).toEither must beLeft
 
   def defaultFound =
-    run(option[String]('a', "").default("c"), List("-a", "b")) ==== "b".right
+    run(flag[String]('a', "").default("c"), List("-a", "b")) ==== "b".right
 
   def defaultMissing =
-    run(option[String]('a', "").default("c"), List()) ==== "c".right
+    run(flag[String]('a', "").default("c"), List()) ==== "c".right
 
   def optionFound =
-    run(option[String]('a', "").option, List("-a", "b")) ==== Some("b").right
+    run(flag[String]('a', "").option, List("-a", "b")) ==== Some("b").right
 
   def optionMissing =
-    run(option[String]('a', "").option, List()) ==== None.right
+    run(flag[String]('a', "").option, List()) ==== None.right
 }

--- a/src/test/scala/io.mth.pirate/ReadSpec.scala
+++ b/src/test/scala/io.mth.pirate/ReadSpec.scala
@@ -19,9 +19,9 @@ class ReadSpec extends test.Spec { def is = s2"""
   Symmetric
     Char                              ${symmetric[Char]}
     String                            ${symmetric[String]}
-    Short                             ${symmetric[scala.Short]}
+    Short                             ${symmetric[Short]}
     Int                               ${symmetric[Int]}
-    Long                              ${symmetric[scala.Long]}
+    Long                              ${symmetric[Long]}
     Double                            ${symmetric[Double]}
     Boolean                           ${symmetric[Boolean]}
     BigInt                            ${symmetric[BigInt]}
@@ -56,9 +56,9 @@ class ReadSpec extends test.Spec { def is = s2"""
 
   Read.of[Char]
   Read.of[String]
-  Read.of[scala.Short]
+  Read.of[Short]
   Read.of[Int]
-  Read.of[scala.Long]
+  Read.of[Long]
   Read.of[Double]
   Read.of[Boolean]
   Read.of[BigInt]


### PR DESCRIPTION
The goals here are to:
1. Move away from the temporary Pirate\* prefixed names.
2. Make thinks consistent throughout.
3. Make things read ok.
4. Avoid name clashes with standard library.

Have generally erred on the conservative side to avoid clashes for now, can do another sweep later on, to give things nicer, shorter names if possible at a later stage.
