### PR TITLE
Ensure minimum width for text usage

### DIFF
--- a/src/main/scala/pirate/Text.scala
+++ b/src/main/scala/pirate/Text.scala
@@ -9,8 +9,10 @@ object Text {
   /**
    * Wrap text at width. Prepend an indent on each line of indent.
    */
-  def wrap(firstText: String, flagIndent: Int)(text: String, width: Int, indent: Int): String = {
+  def wrap(firstText: String, flagIndent: Int)(text: String, widthFull: Int, indent: Int): String = {
     val spacer = space(indent)
+    // We need to pick a minimum size for the text
+    val width = math.max(widthFull, 50)
     val firstSpacer = space(Math.max(1,indent - firstText.length - flagIndent))
 
     // Add 1 for hyphen + newline

--- a/src/test/scala/pirate/TextSpec.scala
+++ b/src/test/scala/pirate/TextSpec.scala
@@ -11,6 +11,7 @@ class TextSpec extends spec.Spec { def is = s2"""
   correct length                                  $length
   wrap no longer than width                       $width
   wrap no longer than width + indent              $indent
+  handle negative widths                          $negativeWidth
   never lose content                              $safe
 
 """
@@ -24,6 +25,10 @@ class TextSpec extends spec.Spec { def is = s2"""
   def width = prop((l: LongLine) => wrap("", 0)(l.value, 80, 0).split('\n').forall(_.length <= 80))
 
   def indent = prop((l: LongLine) => wrap("", 0)(l.value, 80, 10).split('\n').forall(_.length <= 90))
+
+  def negativeWidth = prop((l: LongLine, s: SmallInt) =>
+    wrap("", 0)(l.value, 50 - s.value, 10).split('\n').forall(_.length <= 90)
+  )
 
   def safe = prop((l: LongLine) => drains(l.value, wrap("", 0)(l.value, 80, 0)))
 


### PR DESCRIPTION
To avoid `NegativeArraySizeException` when the failed command is longer than 80 characters.

/cc @FrontierOtr 