### PR TITLE
Re-introduce mandatory name for switch/flag

### DIFF
--- a/src/main/scala/pirate.internal/ParseTraversal.scala
+++ b/src/main/scala/pirate.internal/ParseTraversal.scala
@@ -91,26 +91,26 @@ object ParseTraversal {
     StateT[P, List[String], A](run)
 
   def optMatches[A](parser: Parser[A], w: ParsedWord): Option[StateArg[A]] = parser match {
-    case SwitchParser(meta, a) =>
+    case SwitchParser(flag, _, a) =>
       w.name match {
         case ShortParsedName(c) =>
-          meta.hasShort(c).option(
+          flag.hasShort(c).option(
             update[A](args =>
               ((w.value.map(s => "-" ++ s).toList ++ args) -> a).pure[P]
             ))
         case LongParsedName(s) =>
-          meta.hasLong(s).option(a.pure[StateArg])
+          flag.hasLong(s).option(a.pure[StateArg])
       }
-    case FlagParser(meta, p) =>
+    case FlagParser(flag, meta, p) =>
       w.name match {
         case ShortParsedName(c) =>
-          meta.hasShort(c).option(
+          flag.hasShort(c).option(
             update[A](args => p.read(w.value.toList ++ args) match {
               case -\/(e) => errorP(toParseError(e))
               case \/-(r) => r.pure[P]
             }))
         case LongParsedName(s) =>
-          meta.hasLong(s).option(
+          flag.hasLong(s).option(
             update[A](args => p.read(w.value.toList ++ args) match {
               case -\/(e) => errorP(toParseError(e))
               case \/-(r) => r.pure[P]

--- a/src/main/scala/pirate/Flags.scala
+++ b/src/main/scala/pirate/Flags.scala
@@ -10,30 +10,30 @@ trait Flags {
 
   // A simple parser to show the help text without disrupting the main parser
   def helper =
-    abort(short('h') |+| long("help") |+| description("Prints the synopsis and a list of options and arguments."), ShowHelpText(None))
+    abort(both('h', "help"), description("Prints the synopsis and a list of options and arguments."), ShowHelpText(None))
 
   // A helper which optionally shows the help text for subcommands.
   def helperX: Parse[Option[Unit]] =
-    parse(FlagParser(short('h') |+| long("help") |+| description("Prints the synopsis and a list of the most commonly used commands. If a subcommand is named this option will show the synposis for said command."), Read.string.option.flatMap(s => Read.error[Unit](ShowHelpText(s))))).option
+    parse(FlagParser(both('h', "help"), description("Prints the synopsis and a list of the most commonly used commands. If a subcommand is named this option will show the synposis for said command."), Read.string.option.flatMap(s => Read.error[Unit](ShowHelpText(s))))).option
 
   // A simple parser to show the application version
   def version(v: String): Parse[Option[Unit]] =
-    abort(short('v') |+| long("version") |+| description("Prints the application version."), ShowVersion(v))
+    abort(both('v', "version"), description("Prints the application version."), ShowVersion(v))
 
-  def abort(meta: Metadata, error: ReadError): Parse[Option[Unit]] =
-    parse(FlagParser(meta, Read.error(error))).option
+  def abort(flag: Name, meta: Metadata, error: ReadError): Parse[Option[Unit]] =
+    parse(FlagParser(flag, meta, Read.error(error))).option
 
-  def terminator[A](meta: Metadata, a: A): Parse[A] =
-    parse(SwitchParser(meta, a))
+  def terminator[A](flag: Name, meta: Metadata, a: A): Parse[A] =
+    parse(SwitchParser(flag, meta, a))
 
-  def terminatorx[A: Read, B](meta: Metadata, f: Option[A] => B): Parse[B] =
-    parse(FlagParser(meta, Read.of[A].option).map(f))
+  def terminatorx[A: Read, B](flag: Name, meta: Metadata, f: Option[A] => B): Parse[B] =
+    parse(FlagParser(flag, meta, Read.of[A].option).map(f))
 
-  def switch(meta: Metadata): Parse[Boolean] =
-    parse(SwitchParser(meta, true)) ||| false.pure[Parse]
+  def switch(flag: Name, meta: Metadata): Parse[Boolean] =
+    parse(SwitchParser(flag, meta, true)) ||| false.pure[Parse]
 
-  def flag[A: Read](meta: Metadata): Parse[A] =
-    parse(FlagParser(meta, Read.of[A]))
+  def flag[A: Read](flag: Name, meta: Metadata): Parse[A] =
+    parse(FlagParser(flag, meta, Read.of[A]))
 
   def argument[A: Read](meta: Metadata): Parse[A] =
     parse(ArgumentParser(meta, Read.of[A]))
@@ -44,10 +44,19 @@ trait Flags {
   def subcommand[A](sub: Command[A]): Parse[A] =
     parse(CommandParser(sub))
 
-  def hidden: Metadata = Metadata(None, None, None, false)
-  def metavar(d: String): Metadata = Metadata(None, None, d.some, true)
-  def description(d: String): Metadata = Metadata(None, d.some, None, true)
-  implicit def NameSyntax(n: Name): Metadata = Metadata(n.some, None, None, true)
-  def short(s: Char) = Metadata(ShortName(s).some, None, None, true)
-  def long(l: String) = Metadata(LongName(l).some, None, None, true)
+  def empty: Metadata =
+    Metadata(None, None, true)
+  def hidden: Metadata =
+    Metadata(None, None, false)
+  def metavar(d: String): Metadata =
+    Metadata(None, d.some, true)
+  def description(d: String): Metadata =
+    Metadata(d.some, None, true)
+
+  def short(s: Char): Name =
+    ShortName(s)
+  def long(l: String): Name =
+    LongName(l)
+  def both(s: Char, l: String): Name =
+    BothName(s, l)
 }

--- a/src/main/scala/pirate/Metadata.scala
+++ b/src/main/scala/pirate/Metadata.scala
@@ -2,20 +2,11 @@ package pirate
 
 import scalaz._
 
-case class Metadata(names: Option[Name], description: Option[String], metavar: Option[String], visible: Boolean) {
-  def hasShort(s: Char): Boolean = names match  {
-    case Some(n) => n.hasShort(s)
-    case None    => false
-  }
-  def hasLong(l: String): Boolean = names match  {
-    case Some(n) => n.hasLong(l)
-    case None    => false
-  }
-}
+case class Metadata(description: Option[String], metavar: Option[String], visible: Boolean)
 
 object Metadata {
   implicit def MetadataMonoid: Monoid[Metadata] = new Monoid[Metadata] {
-    def zero = Metadata(None, None, None, true)
-    def append(m1: Metadata, m2: => Metadata) = Metadata(Name.combineOpt(m1.names, m2.names), m1.description orElse m2.description, m1.metavar orElse m2.metavar, m1.visible && m2.visible)
+    def zero = Metadata(None, None, true)
+    def append(m1: Metadata, m2: => Metadata) = Metadata(m1.description orElse m2.description, m1.metavar orElse m2.metavar, m1.visible && m2.visible)
   }
 }

--- a/src/main/scala/pirate/Name.scala
+++ b/src/main/scala/pirate/Name.scala
@@ -14,10 +14,10 @@ sealed trait Name {
   }
 
   def hasShort(s: Char): Boolean =
-    short.map(_ == s).getOrElse(false)
+    short.exists(_ == s)
 
   def hasLong(l: String): Boolean =
-    long.map(_ == l).getOrElse(false)
+    long.exists(_ == l)
 
   def render: String = this match {
     case ShortName(s) => s"-${s}"

--- a/src/main/scala/pirate/Parser.scala
+++ b/src/main/scala/pirate/Parser.scala
@@ -4,10 +4,10 @@ import scalaz._
 
 sealed trait Parser[A] {
   def map[B](f: A => B): Parser[B] = this match {
-    case SwitchParser(meta, a) =>
-      SwitchParser(meta, f(a))
-    case FlagParser(meta, p) =>
-      FlagParser(meta, p.map(f))
+    case SwitchParser(flag, meta, a) =>
+      SwitchParser(flag, meta, f(a))
+    case FlagParser(flag, meta, p) =>
+      FlagParser(flag, meta, p.map(f))
     case ArgumentParser(meta, p) =>
       ArgumentParser(meta, p.map(f))
     case CommandParser(sub) =>
@@ -19,15 +19,15 @@ sealed trait Parser[A] {
     case _                    => false
   }
   def isVisible: Boolean = this match {
-    case SwitchParser(meta, _) => meta.visible
-    case FlagParser(meta, _) => meta.visible
+    case SwitchParser(_, meta, _) => meta.visible
+    case FlagParser(_, meta, _) => meta.visible
     case ArgumentParser(meta, _) => meta.visible
     case CommandParser(sub) => true
   }
 }
 
-case class SwitchParser[A](meta: Metadata, a: A) extends Parser[A]
-case class FlagParser[A](meta: Metadata, p: Read[A]) extends Parser[A]
+case class SwitchParser[A](flag: Name, meta: Metadata, a: A) extends Parser[A]
+case class FlagParser[A](flag: Name, meta: Metadata, p: Read[A]) extends Parser[A]
 case class ArgumentParser[A](meta: Metadata, p: Read[A]) extends Parser[A]
 case class CommandParser[A](sub: Command[A]) extends Parser[A]
 

--- a/src/main/scala/pirate/Usage.scala
+++ b/src/main/scala/pirate/Usage.scala
@@ -28,10 +28,10 @@ object Usage {
     })
 
   def flags[X](p: Parser[X], info: OptHelpInfo): Info = p match {
-    case SwitchParser(meta, a) =>
-      SwitchInfo(meta.names.get, meta.description, info.multi, info.dfault)
-    case FlagParser(meta, p) =>
-      FlagInfo(meta.names.get, meta.description, meta.metavar, info.multi, info.dfault)
+    case SwitchParser(flag, meta, a) =>
+      SwitchInfo(flag, meta.description, info.multi, info.dfault)
+    case FlagParser(flag, meta, p) =>
+      FlagInfo(flag, meta.description, meta.metavar, info.multi, info.dfault)
     case CommandParser(sub) =>
       CommandInfo(sub.name, sub.description, Usage.tree(sub.parse))
     case ArgumentParser(meta, p) =>

--- a/src/test/scala/pirate.example/CutExample.scala
+++ b/src/test/scala/pirate.example/CutExample.scala
@@ -16,20 +16,20 @@ case class FieldCut(list: String, suppress: Boolean, delimiter: Char, files: Lis
 // FIX descriptions on fields
 object CutMain extends PirateMainIO[Cut] {
   val byte: Parse[Cut] = (ByteCut |*| (
-    flag[String](short('b') |+| metavar("list"))
-  , switch(short('n')).not
+    flag[String](short('b'), metavar("list"))
+  , switch(short('n'), empty).not
   , arguments[File](metavar("file"))
   )).map(x => x)
 
   val char: Parse[Cut] = (CharCut |*| (
-    flag[String](short('c') |+| metavar("list"))
+    flag[String](short('c'), metavar("list"))
   , arguments[File](metavar("file"))
   )).map(x => x)
 
   val field: Parse[Cut] = (FieldCut |*| (
-    flag[String](short('f') |+| metavar("list"))
-  , switch(short('s'))
-  , flag[Char](short('d') |+| long("delimiter")).default('\t')
+    flag[String](short('f'), metavar("list"))
+  , switch(short('s'), empty)
+  , flag[Char](both('d', "delimiter"), empty).default('\t')
   , arguments[File](metavar("file"))
   )).map(x => x)
 

--- a/src/test/scala/pirate.example/GitExample.scala
+++ b/src/test/scala/pirate.example/GitExample.scala
@@ -21,37 +21,37 @@ case class GitRm(force: Boolean, dryRun: Boolean, recurse: Boolean, cached: Bool
 
 object GitMain extends PirateMainIO[Git] {
   val version: Parse[GitCommand] =
-    terminator(long("version") |+| short('v') |+| description("Prints the Git suite version that the git program came from."), GitVersion)
+    terminator(both('v', "version"), description("Prints the Git suite version that the git program came from."), GitVersion)
 
   val cwd: Parse[Option[String]] =
-    flag[String](short('C') |+| metavar("<path>") |+| description("Run as if git was started in <path> instead of the current working directory.")).option
+    flag[String](short('C'), metavar("<path>") |+| description("Run as if git was started in <path> instead of the current working directory.")).option
 
   val conf: Parse[Option[String]] =
-    flag[String](short('c') |+| metavar("<name>=<value>") |+| description("Pass a configuration parameter to the command.")).option
+    flag[String](short('c'), metavar("<name>=<value>") |+| description("Pass a configuration parameter to the command.")).option
 
   val exec: Parse[Option[String]] =
-    flag[String](long("exec-path") |+| metavar("<path>") |+| description("Path to wherever your core Git programs are installed.")).option
+    flag[String](long("exec-path"), metavar("<path>") |+| description("Path to wherever your core Git programs are installed.")).option
 
   val html: Parse[GitCommand] =
-    terminator(long("html-path") |+| description("Print the path, without trailing slash, where Git's HTML documentation is installed and exit."), GitHtmlPath)
+    terminator(long("html-path"), description("Print the path, without trailing slash, where Git's HTML documentation is installed and exit."), GitHtmlPath)
 
   val man: Parse[GitCommand] =
-    terminator(long("man-path") |+| description("Print the manpath (see man(1)) for the man pages for this version of Git and exit."), GitManPath)
+    terminator(long("man-path"), description("Print the manpath (see man(1)) for the man pages for this version of Git and exit."), GitManPath)
 
   val info: Parse[GitCommand] =
-    terminator(long("info-path"), GitInfoPath)
+    terminator(long("info-path"), empty, GitInfoPath)
 
   // Applicitive style GitAdd |*| (switch ...) leads to invariance issues.
-  val add: Parse[GitCommand] = (switch(long("force") |+| short('f'))
-                            |@| switch(long("interactive") |+| short('i'))
-                            |@| switch(long("patch") |+| short('p'))
-                            |@| switch(long("edit") |+| short('e'))
+  val add: Parse[GitCommand] = (switch(both('f', "force"), empty)
+                            |@| switch(both('i', "interactive"), empty)
+                            |@| switch(both('p', "patch"), empty)
+                            |@| switch(both('e', "edit"), empty)
                             |@| arguments[File](metavar("paths")))(GitAdd)
 
-  val rm: Parse[GitCommand] = (switch(long("force") |+| short('f'))
-                            |@| switch(long("dry-run") |+| short('n'))
-                            |@| switch(short('r'))
-                            |@| switch(long("cached"))
+  val rm: Parse[GitCommand] = (switch(both('f', "force"), empty)
+                            |@| switch(both('n', "dry-run"), empty)
+                            |@| switch(short('r'), empty)
+                            |@| switch(long("cached"), empty)
                             |@| arguments[File](metavar("paths")))(GitRm)
 
   def git(cmd: Parse[GitCommand]): Parse[Git] =

--- a/src/test/scala/pirate.example/InteractiveExample.scala
+++ b/src/test/scala/pirate.example/InteractiveExample.scala
@@ -2,8 +2,6 @@ package pirate.example
 
 import pirate._, Pirate._
 
-import scalaz._, Scalaz._
-
 // FIX actually implement this, currently just some hard coded examples that use the internals.
 object InteractiveExample {
   case class Example(
@@ -13,9 +11,9 @@ object InteractiveExample {
   )
 
   val example = Example |*| (
-    switch(short('s'))
-  , flag[String](short('c') |+| description("STRING"))
-  , flag[Int](short('n') |+| description("INT"))
+    switch(short('s'), empty)
+  , flag[String](short('c'), description("STRING"))
+  , flag[Int](short('n'), description("INT"))
   )
 
  val command = example ~ "example" ~~

--- a/src/test/scala/pirate.example/MthExample.scala
+++ b/src/test/scala/pirate.example/MthExample.scala
@@ -14,12 +14,12 @@ object MthExample {
   case object Version extends Args
 
   val example: Parse[Args] = (Example |*| (
-    switch(short('s'))
-  , flag[String](short('c') |+| description("STRING"))
-  , flag[Int](short('n') |+| description("INT"))
+    switch(short('s'), empty)
+  , flag[String](short('c'), description("STRING"))
+  , flag[Int](short('n'), description("INT"))
   )).map(x => x)
 
-  val all = switch(short('h')).as[Args](Help) ||| switch(short('v')).as(Version) ||| example
+  val all = switch(short('h'), empty).as[Args](Help) ||| switch(short('v'), empty).as(Version) ||| example
 
  val command = all ~ "example" ~~
   s"""|An interactive example for pirate with variants.

--- a/src/test/scala/pirate.spec/Arbitraries.scala
+++ b/src/test/scala/pirate.spec/Arbitraries.scala
@@ -71,19 +71,18 @@ object Arbitraries {
     mvar <- arbitrary[Option[String]]
     hid <- arbitrary[Boolean]
     a <- arbitrary[A]
-  } yield SwitchParser[A](Metadata(Some(n), desc, mvar, hid), a))
+  } yield SwitchParser[A](n, Metadata(desc, mvar, hid), a))
 
   implicit def FlagParserArbitrary[A: Read: Arbitrary]: Arbitrary[FlagParser[A]] = Arbitrary(for {
     n <- arbitrary[Name]
     desc <- arbitrary[Option[String]]
     mvar <- arbitrary[Option[String]]
     hid <- arbitrary[Boolean]
-  } yield FlagParser[A](Metadata(Some(n), desc, mvar, hid), Read.of[A]))
+  } yield FlagParser[A](n, Metadata(desc, mvar, hid), Read.of[A]))
 
   implicit def ArgumentParserArbitrary[A: Read: Arbitrary]: Arbitrary[ArgumentParser[A]] = Arbitrary(for {
-    n <- arbitrary[Option[Name]]
     desc <- arbitrary[Option[String]]
     mvar <- arbitrary[Option[String]]
     hid <- arbitrary[Boolean]
-  } yield ArgumentParser[A](Metadata(n, desc, mvar, hid), Read.of[A]))
+  } yield ArgumentParser[A](Metadata(desc, mvar, hid), Read.of[A]))
 }

--- a/src/test/scala/pirate/InterpreterSpec.scala
+++ b/src/test/scala/pirate/InterpreterSpec.scala
@@ -55,66 +55,66 @@ class InterpreterSpec extends spec.Spec { def is = s2"""
   def run[A](p: Parse[A], args: List[String]): ParseError \/ A = Interpreter.run(p, args)._2
 
   def testA(name: String): Parse[TestCommand] =
-    terminator(long(name), TestA)
+    terminator(long(name), Flags.empty, TestA)
 
   def testB(name: String): Parse[TestCommand] =
-    terminator(long(name), TestB)
+    terminator(long(name), Flags.empty, TestB)
 
   def wrap(cmd: Parse[TestCommand]): Parse[TestWrapper] =
     cmd.map(TestWrapper)
 
   def requiredFound =
-    run(flag[String]( short('a')), List("-a", "b")) ==== "b".right
+    run(flag[String](short('a'), Flags.empty), List("-a", "b")) ==== "b".right
 
   def requiredMissingA =
-    run((flag[String](short('a')) |@| flag[String](short('b')))(_ -> _), List()).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false)), ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
+    run((flag[String](short('a'), Flags.empty) |@| flag[String](short('b'), Flags.empty))(_ -> _), List()).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false)), ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
 
   def requiredMissingB =
-    run((flag[String](short('a')) |@| flag[String](short('b')))(_ -> _), List("-b", "c")).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false))))))
+    run((flag[String](short('a'), Flags.empty) |@| flag[String](short('b'), Flags.empty))(_ -> _), List("-b", "c")).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false))))))
 
   def requiredMissingC =
-    run((flag[String](short('a')) |@| flag[String](short('b')))(_ -> _), List("-a", "c")).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
+    run((flag[String](short('a'), Flags.empty) |@| flag[String](short('b'), Flags.empty))(_ -> _), List("-a", "c")).toEither must beLeft(ParseErrorMissing(ParseTreeAp(List(ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
 
   def requiredMissingAlts =
-    run(flag[String](short('a')) ||| flag[String](short('b')), List()).toEither must beLeft(ParseErrorMissing(ParseTreeAlt(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false)), ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
+    run(flag[String](short('a'), Flags.empty) ||| flag[String](short('b'), Flags.empty), List()).toEither must beLeft(ParseErrorMissing(ParseTreeAlt(List(ParseTreeLeaf(FlagInfo(ShortName('a'), None, None, false, false)), ParseTreeLeaf(FlagInfo(ShortName('b'), None, None, false, false))))))
 
   def defaultFound =
-    run(flag[String](short('a')).default("c"), List("-a", "b")) ==== "b".right
+    run(flag[String](short('a'), Flags.empty).default("c"), List("-a", "b")) ==== "b".right
 
   def defaultMissing =
-    run(flag[String](short('a')).default("c"), List()) ==== "c".right
+    run(flag[String](short('a'), Flags.empty).default("c"), List()) ==== "c".right
 
   def optionFound =
-    run(flag[String](short('a')).option, List("-a", "b")) ==== Some("b").right
+    run(flag[String](short('a'), Flags.empty).option, List("-a", "b")) ==== Some("b").right
 
   def optionMissing =
-    run(flag[String](short('a')).option, List()) ==== None.right
+    run(flag[String](short('a'), Flags.empty).option, List()) ==== None.right
 
   def assignmentFound = prop((name: LongNameString, value: String) => {
-    run(flag[String](long(name.s)), List(s"--${name.s}=$value")) ==== value.right
+    run(flag[String](long(name.s), Flags.empty), List(s"--${name.s}=$value")) ==== value.right
   })
 
   def assignmentMissing = prop((name: Name, lname: LongNameString, value: String) => name.long != Some(lname.s) ==> {
-    run(flag[String](name), List(s"--${lname.s}=$value")).toEither must beLeft
+    run(flag[String](name, Flags.empty), List(s"--${lname.s}=$value")).toEither must beLeft
   })
 
   def switchesOn =
-    run(switch(short('a')), List("-a")) ==== true.right
+    run(switch(short('a'), Flags.empty), List("-a")) ==== true.right
 
   def switchesOff =
-    run(switch(short('a')), Nil) ==== false.right
+    run(switch(short('a'), Flags.empty), Nil) ==== false.right
 
   def multipleSwitches =
-    run((switch(short('a')) |@| switch(short('b')))(_ -> _), List("-ab")) ==== (true, true).right
+    run((switch(short('a'), Flags.empty) |@| switch(short('b'), Flags.empty))(_ -> _), List("-ab")) ==== (true, true).right
 
   def flagAfterSwitch =
-    run((switch(short('a')) |@| flag[String](short('b')))(_ -> _), List("-ab", "c")) ==== (true, "c").right
+    run((switch(short('a'), Flags.empty) |@| flag[String](short('b'), Flags.empty))(_ -> _), List("-ab", "c")) ==== (true, "c").right
 
   def shortFlagPost =
-    run(flag[String]( short('a')), List("-ab")) ==== "b".right
+    run(flag[String](short('a'), Flags.empty), List("-ab")) ==== "b".right
 
   def flagsLength =
-    run(terminator(short('t'), ()).many.map(_.length), List("-ttt")) ==== 3.right
+    run(terminator(short('t'), Flags.empty, ()).many.map(_.length), List("-ttt")) ==== 3.right
 
   def positionalArgs =
     run((argument[String](metavar("src")) |@| argument[String](metavar("dst")))(_ -> _), List("/tmp/src", "tmp/dst")) ==== ("/tmp/src", "tmp/dst").right
@@ -134,11 +134,11 @@ class InterpreterSpec extends spec.Spec { def is = s2"""
   def someFailsOnEmpty = run(argument[String](metavar("files")).some, List()).toEither must beLeft
 
   def invalidOpt = {
-    run(flag[String](short('a')), List("-c")) ==== ParseErrorInvalidOption("-c").left
+    run(flag[String](short('a'), Flags.empty), List("-c")) ==== ParseErrorInvalidOption("-c").left
   }
 
   def invalidArg = {
-    run(flag[String](short('a')), List("file.txt")) ==== ParseErrorInvalidArgument("file.txt").left
+    run(flag[String](short('a'), Flags.empty), List("file.txt")) ==== ParseErrorInvalidArgument("file.txt").left
   }
 
   def intArgString = {


### PR DESCRIPTION
To make this a less intrusive change we could also introduce `case class NameAndMeta(name: Name, meta: Meta)` where `short`/`long`/`both` return that with the empty meta.

EDIT: Actually that still doesn't (necessarily) help, or at least it would have a monoid so the call site will still have to change.